### PR TITLE
chore(test): CI smoke test touch utilities stack

### DIFF
--- a/stacks/utilities/docker-compose.yaml
+++ b/stacks/utilities/docker-compose.yaml
@@ -71,3 +71,4 @@ services:
             - AUTH_SECRET=${PEANUT_AUTH_SECRET}
         volumes:
             - /root/docker/utilities-stack/peanut/config:/config
+# smoke-test Fri Aug 22 20:11:11 EDT 2025


### PR DESCRIPTION
This pull request introduces a minor change to the `docker-compose.yaml` file, adding a comment for a smoke test with a timestamp. No functional changes were made.