### PR TITLE
Update CI workflow to remove push branches-ignore

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,6 @@
 name: CI - Validate Stacks, Security & Lint
 
 on:
-    push:
-        branches-ignore: ["main"]
     pull_request:
         branches: ["main"]
     schedule:


### PR DESCRIPTION
This pull request makes a small change to the CI workflow configuration. The workflow will now only run on pull requests to the `main` branch, and will no longer run on direct pushes to any branch.