### PR TITLE
Ci/add gate job

### DIFF
--- a/stacks/vaultwarden/docker-compose.yaml
+++ b/stacks/vaultwarden/docker-compose.yaml
@@ -13,7 +13,6 @@ services:
             - ADMIN_TOKEN=${VAULTWARDEN_ADMIN_TOKEN}
             - UID=0
             - GID=0
-        invalid_field: true
 
     vaultwarden-backup:
         image: bruceforce/vaultwarden-backup:latest

--- a/stacks/wireguard/docker-compose.yaml
+++ b/stacks/wireguard/docker-compose.yaml
@@ -29,5 +29,3 @@ services:
         sysctls:
             - net.ipv4.ip_forward=1
             - net.ipv4.conf.all.src_valid_mark=1
-
-        # TEST


### PR DESCRIPTION
This pull request updates the `.github/workflows/ci.yaml` file to improve the clarity and reliability of CI job names and results. The most significant change is the addition of a new job that summarizes the outcome of all critical CI checks, providing a clear "gate" for passing the pipeline. Several job names have also been clarified for better readability.

**CI Workflow Improvements:**

* Added a new `verified_summary` job that acts as a CI gate, aggregating the results of all required jobs and providing a clear summary indicating whether all checks have passed. This job treats a skipped `validate_stacks` as a success and outputs a summary to the GitHub step summary. This gate is used as a required check for auto-merging.

**Job Name Clarifications:**

* Updated job names throughout the workflow for improved clarity and consistency:
    - `meta_lint` is now "Lint — Workflows and Docs"
    - `security_secrets` is now "Security — Secrets"
    - `detect_changes` is now "Detect — Changed Stacks"
    - `validate_stacks` is now "Validate — Docker and YAML (per stack)"
    - `persist_broken_cache` is now "Cache — Broken Stacks"
    - `security_images` is now "Security — Container Images"