### PR TITLE
ci(github): prevent PRs from uploading Trivy cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -492,6 +492,7 @@ jobs:
                   key: trivy-db-${{ runner.os }}-W${{ env.CACHE_EPOCH }}-v1
                   restore-keys: |
                       trivy-db-${{ runner.os }}-
+                  lookup-only: ${{ !(github.event_name == 'schedule' || github.ref == 'refs/heads/main') }}
 
             - name: Install Trivy (CLI)
               run: |


### PR DESCRIPTION
Ensure only scheduled runs and main branch can create or update the shared weekly Trivy DB cache. Pull requests now restore-only to avoid duplicate cache entries.