### PR TITLE
ci(github): split restore/save for Trivy DB cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -428,7 +428,7 @@ jobs:
                   path: ${{ env.BROKEN_CACHE_PATH }}
                   key: broken-stacks-${{ github.run_id }}
 
-    # 4) Image security — gated inline (no separate gate job)
+    # 4) Image security
     security_images:
         name: Security — Container Images
         if: ${{ !cancelled() }}
@@ -485,14 +485,15 @@ jobs:
                   # ISO week: YYYY-WW (e.g., 2025-34), zero-padded week
                   echo "CACHE_EPOCH=$(date -u +%G-%V)" >> "$GITHUB_ENV"
 
-            - name: Cache Trivy DB
-              uses: actions/cache@v4
+            # --- Restore for everyone (PRs, branches, main, schedule) ---
+            - name: Restore Trivy DB cache
+              id: trivy_restore
+              uses: actions/cache/restore@v4
               with:
                   path: ~/.cache/trivy
                   key: trivy-db-${{ runner.os }}-W${{ env.CACHE_EPOCH }}-v1
                   restore-keys: |
                       trivy-db-${{ runner.os }}-
-                  lookup-only: ${{ !(github.event_name == 'schedule' || github.ref == 'refs/heads/main') }}
 
             - name: Install Trivy (CLI)
               run: |
@@ -513,6 +514,14 @@ jobs:
                     echo "::endgroup::"
                   done < images.txt
                   (( failed == 0 ))
+
+            # --- Save ONLY from schedule or manual run on main (single writer) ---
+            - name: Save Trivy DB cache
+              if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+              uses: actions/cache/save@v4
+              with:
+                  path: ~/.cache/trivy
+                  key: trivy-db-${{ runner.os }}-W${{ env.CACHE_EPOCH }}-v1
 
             # --- Keep only the latest 4 weekly caches per OS ---
             - name: Prune old Trivy caches (keep last 4)


### PR DESCRIPTION
Use `cache/restore` for all runs and restrict `cache/save` to scheduled or main runs. This avoids duplicate PR caches and ensures a single writer per weekly Trivy DB key.

- Rename step to clarify restore vs save roles
- Remove lookup-only in favor of explicit save gating