### PR TITLE
chore(stacks): disable env_file in homepage compose

### DIFF
--- a/stacks/homepage/docker-compose.yaml
+++ b/stacks/homepage/docker-compose.yaml
@@ -5,8 +5,8 @@ services:
         restart: unless-stopped
         ports:
             - 3100:3000
-        env_file:
-            - stack.env
+        # env_file:
+        #     - stack.env
         environment:
             - HOMEPAGE_ALLOWED_HOSTS=${HOMEPAGE_ALLOWED_HOSTS}
         volumes:


### PR DESCRIPTION
Commented out the env_file section in homepage's docker-compose. This avoids loading stack.env and instead relies on inline environment variables.