### PR TITLE
feat(vaultwarden): switch to ttionya backup w/ smtp

### DIFF
--- a/stacks/vaultwarden/docker-compose.yaml
+++ b/stacks/vaultwarden/docker-compose.yaml
@@ -15,21 +15,59 @@ services:
             - GID=0
 
     vaultwarden-backup:
-        image: bruceforce/vaultwarden-backup:latest
+        image: ttionya/vaultwarden-backup:latest
         container_name: vaultwarden-backup
         restart: always
         depends_on:
             - vaultwarden
         volumes:
-            - /root/docker/security-stack/vaultwarden/data:/data:ro
-            - /root/docker/security-stack/vaultwarden/backup:/backup
+            - /root/docker/security-stack/vaultwarden/data:/bitwarden/data:ro
+            - /root/docker/security-stack/vaultwarden/rclone-config:/config
+            - /mnt/vaultwarden-backups:/backup # NAS NFS bind mount
             - /etc/localtime:/etc/localtime:ro
             - /etc/timezone:/etc/timezone:ro
         environment:
-            - CRON_TIME=0 * * * * # every hour
-            - DELETE_AFTER=30 # keep backups for 30 days
-            - BACKUP_DIR=/backup
-            - TIMESTAMP=true
-            - ENCRYPTION_PASSWORD=${VW_BACKUP_PASSWORD}
-            - UID=0
-            - GID=0
+            - TIMEZONE=America/New_York
+
+            # Scheduling & retention
+            - CRON=0 * * * *
+            - BACKUP_KEEP_DAYS=30
+
+            # Archive & encryption
+            - ZIP_ENABLE=TRUE
+            - ZIP_TYPE=7z
+            - ZIP_PASSWORD=${VW_BACKUP_PASSWORD}
+
+            # rclone destination
+            - RCLONE_REMOTE_NAME=BitwardenBackup
+            - RCLONE_REMOTE_DIR=/backup
+
+            # Notifications - SMTP
+            - MAIL_SMTP_ENABLE=TRUE
+            - MAIL_TO=${VW_BACKUP_EMAIL_RECIPIENT} # recipient(s)
+            - MAIL_WHEN_SUCCESS=TRUE # disable success emails
+            - MAIL_WHEN_FAILURE=TRUE # enable only on failures
+            - MAIL_SMTP_VARIABLES=-S smtp-use-starttls -S smtp=smtp://smtp.gmail.com:587 -S smtp-auth=login -S smtp-auth-user=${SMTP_EMAIL} -S smtp-auth-password=${SMTP_PASSWORD} -S from=${SMTP_EMAIL}
+
+            # Optional display name
+            - DISPLAY_NAME=vaultwarden
+
+    # vaultwarden-backup:
+    #     image: bruceforce/vaultwarden-backup:latest
+    #     container_name: vaultwarden-backup
+    #     restart: always
+    #     depends_on:
+    #         - vaultwarden
+    #     volumes:
+    #         - /root/docker/security-stack/vaultwarden/data:/data:ro
+    #         - /root/docker/security-stack/vaultwarden/backup:/backup
+    #         - /etc/localtime:/etc/localtime:ro
+    #         - /etc/timezone:/etc/timezone:ro
+    #     environment:
+    #         - CRON_TIME=0 * * * * # every hour
+    #         - DELETE_AFTER=30 # keep backups for 30 days
+    #         - BACKUP_DIR=/backup
+    #         - TIMESTAMP=true
+    #         - ENCRYPTION_PASSWORD=${VW_BACKUP_PASSWORD}
+    #         - UID=0
+    #         - GID=0


### PR DESCRIPTION
Replaced bruceforce backup image with ttionya's maintained vaultwarden-backup. Adds rclone config, NAS bind mount, 7z encryption, and SMTP notifications for backup results.

- Use `/bitwarden/data` per README defaults
- Enable hourly cron + 30-day retention
- Add Gmail SMTP vars for failure alerts

---

**GitHub Copilot Summary:**

This pull request updates the configuration for the `vaultwarden-backup` service in the `docker-compose.yaml` file to use a new backup image and significantly enhances the backup process. The changes improve backup storage, encryption, scheduling, and notification capabilities.

**Backup service update and enhancements:**

* Switched the backup image from `bruceforce/vaultwarden-backup:latest` to `ttionya/vaultwarden-backup:latest`, enabling the use of new features and improved compatibility.
* Updated volume mounts to use new paths, including mounting the rclone config and a NAS NFS bind mount for backups, supporting offsite and cloud backup destinations.
* Revised environment variables to support advanced scheduling, retention policies, 7z encrypted archives, rclone remote destinations, and SMTP email notifications for backup status.
* Commented out the old backup service configuration for reference and rollback if needed.