### PR TITLE
feat(stacks): add SMTP and email vars to example env

### DIFF
--- a/stacks/vaultwarden/stack.env.example
+++ b/stacks/vaultwarden/stack.env.example
@@ -2,3 +2,6 @@ DOMAIN=https://vaultwarden.domain.com
 SIGNUPS_ALLOWED=false
 VAULTWARDEN_ADMIN_TOKEN='token'
 VW_BACKUP_PASSWORD=backup-password
+VW_BACKUP_EMAIL_RECIPIENT=admin@example.com
+SMTP_EMAIL=example.notifier@gmail.com
+SMTP_PASSWORD=abcd1234efgh5678


### PR DESCRIPTION
Include sample values for SMTP and backup email recipient in `stack.env.example` to guide users configuring backup notifications.

- Add `VW_BACKUP_EMAIL_RECIPIENT`
- Add `SMTP_EMAIL` and `SMTP_PASSWORD`