### PR TITLE
feat(stacks): add Beszel hub/agent templates

### DIFF
--- a/infra-templates/agents/agents.template.yaml
+++ b/infra-templates/agents/agents.template.yaml
@@ -1,7 +1,6 @@
-# Set the following environment variables:
-# - HOSTNAME: The hostname/identifier for this server (e.g., pi-server, homelab-01, etc.)
-# - WATCHTOWER_HTTP_API_TOKEN: API token for Watchtower HTTP API
-# - SLACK_WEBHOOK_URL: Slack webhook URL for notifications
+# If running on a privileged LXC container, add this as well to each container:
+#       security_opt:
+#         - apparmor=unconfined
 
 services:
     dockerproxy:
@@ -18,6 +17,21 @@ services:
             - /var/run/docker.sock:/var/run/docker.sock:ro
         restart: unless-stopped
 
+    beszel-agent:
+        image: henrygd/beszel-agent:latest
+        container_name: beszel-agent
+        restart: unless-stopped
+        network_mode: host
+        volumes:
+            - ./beszel-agent/beszel_agent_data:/var/lib/beszel-agent
+            - ./beszel-agent/beszel_socket:/beszel_socket
+            - /var/run/docker.sock:/var/run/docker.sock:ro
+        environment:
+            LISTEN: /beszel_socket/beszel.sock
+            HUB_URL: http://<IP-OF-BESZEL-HUB-SERVER>:8090
+            TOKEN: ${BESZEL_TOKEN}
+            KEY: ${BESZEL_KEY}
+
     portainer-agent:
         image: portainer/agent:latest
         container_name: portainer-agent
@@ -33,7 +47,7 @@ services:
         command: agent
         container_name: dozzle-agent
         environment:
-            - DOZZLE_HOSTNAME=${HOSTNAME}
+            - DOZZLE_HOSTNAME=hostname
         ports:
             - 7007:7007
         volumes:
@@ -47,19 +61,21 @@ services:
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock
         command: >
-            --schedule "0 0 8 * * *"
+            --schedule "0 0 7 * * *"
             --cleanup
             --rolling-restart
             --log-level info
-            --http-api-metrics
-            --http-api-token ${WATCHTOWER_HTTP_API_TOKEN}
+        # If you want metrics for something like getHomepage, set these:
+        #   --http-api-metrics
+        #   --http-api-token ${WATCHTOWER_HTTP_API_TOKEN}
         environment:
             WATCHTOWER_NOTIFICATIONS: slack
             WATCHTOWER_NOTIFICATION_SLACK_HOOK_URL: ${SLACK_WEBHOOK_URL}
             WATCHTOWER_NOTIFICATION_SLACK_IDENTIFIER: "Watchtower"
             WATCHTOWER_NOTIFICATION_SLACK_CHANNEL: "#watchtower"
             WATCHTOWER_NOTIFICATION_REPORT: "true"
-            WATCHTOWER_NOTIFICATIONS_HOSTNAME: ${HOSTNAME}
+            WATCHTOWER_NOTIFICATIONS_HOSTNAME: hostname
+            WATCHTOWER_NOTIFICATION_TITLE_TAG: "hostname"
             WATCHTOWER_NOTIFICATION_TEMPLATE: |
                 {{- if .Report -}}
                   {{- with .Report -}}
@@ -69,13 +85,13 @@ services:
                       {{- end -}}
                       {{- range .Fresh}}
                 - {{.Name}} ({{.ImageName}}): {{.State}}
-                    {{- end -}}
-                    {{- range .Skipped}}
+                      {{- end -}}
+                      {{- range .Skipped}}
                 - {{.Name}} ({{.ImageName}}): {{.State}}: {{.Error}}
-                    {{- end -}}
-                    {{- range .Failed}}
+                      {{- end -}}
+                      {{- range .Failed}}
                 - {{.Name}} ({{.ImageName}}): {{.State}}: {{.Error}}
-                    {{- end -}}
+                      {{- end -}}
                   {{- end -}}
                 {{- else -}}
                   {{range .Entries -}}{{.Message}}{{"\n"}}{{- end -}}

--- a/proxmox-notes/lxc/ct-dokploy.md
+++ b/proxmox-notes/lxc/ct-dokploy.md
@@ -85,4 +85,15 @@ Only port `443` is needed open on your router for **all** apps.
 
 ---
 
-You're now ready to deploy and securely access unlimited web apps through a single public IP and port!
+## "Invalid Origin" Error When Logging In Fix
+
+Run the following command to fix it:
+
+```bash
+docker service update \
+  --env-rm ALLOWED_ORIGINS \
+  --env-add ALLOWED_ORIGINS=http://localhost:3000,https://dokploy.example.com \
+  dokploy
+```
+
+> Only use https://dokploy.example.com if you actually have it exposed to the internet via something like Nginx Proxy Manager.

--- a/stacks/utilities/docker-compose.yaml
+++ b/stacks/utilities/docker-compose.yaml
@@ -6,8 +6,8 @@ services:
         ports:
             - 8090:8090
         volumes:
-            - /root/docker/beszel/beszel_data:/beszel_data
-            - /root/docker/beszel/beszel_socket:/beszel_socket
+            - /root/docker/utilities-stack/beszel/beszel_data:/beszel_data
+            - /root/docker/utilities-stack/beszel/beszel_socket:/beszel_socket
 
     uptimekuma:
         container_name: uptimekuma

--- a/stacks/utilities/docker-compose.yaml
+++ b/stacks/utilities/docker-compose.yaml
@@ -1,4 +1,14 @@
 services:
+    beszel:
+        image: henrygd/beszel:latest
+        container_name: beszel
+        restart: always
+        ports:
+            - 8090:8090
+        volumes:
+            - /root/docker/beszel/beszel_data:/beszel_data
+            - /root/docker/beszel/beszel_socket:/beszel_socket
+
     uptimekuma:
         container_name: uptimekuma
         image: louislam/uptime-kuma:latest


### PR DESCRIPTION
Introduce Beszel monitoring: add hub service to utilities stack and agent template for host monitoring via hub. Document Dokploy "Invalid Origin" fix and tweak Watchtower schedule and placeholders.

- Add beszel service to stacks/utilities
- Add beszel-agent to infra templates
- Document login origin fix in ct-dokploy notes
- Adjust Watchtower to 07:00 and standardize hostnames

---

**Copilot Summary:**

This pull request introduces configuration changes to support the deployment of the Beszel service and its agent, along with several adjustments to existing agent and notification settings. The main focus is on integrating Beszel into the infrastructure and clarifying/fixing related deployment steps. Below are the most important changes grouped by theme:

**Beszel Integration:**

* Added a new `beszel` service to `stacks/utilities/docker-compose.yaml` for running the Beszel server, exposing port 8090 and mounting persistent data and socket volumes.
* Added a new `beszel-agent` service to `infra-templates/agents/agents.template.yaml` to connect agents to the Beszel hub, including volume mounts and environment variables for configuration.

**Agent and Notification Configuration:**

* Changed hardcoded environment variables `DOZZLE_HOSTNAME` and `WATCHTOWER_NOTIFICATIONS_HOSTNAME` to use a placeholder value `hostname` instead of `${HOSTNAME}` for consistency and clarity; also added `WATCHTOWER_NOTIFICATION_TITLE_TAG`. [[1]](diffhunk://#diff-6116329f74d2f0d62c4be850355e83e7f78d52b5a2a8ba81d7521213c889b716L36-R50) [[2]](diffhunk://#diff-6116329f74d2f0d62c4be850355e83e7f78d52b5a2a8ba81d7521213c889b716L50-R78)
* Updated the Watchtower service's scheduled run time from 8 AM to 7 AM and commented out metrics-related command-line options, providing guidance for enabling them if needed.

**Documentation Updates:**

* Added troubleshooting steps to `proxmox-notes/lxc/ct-dokploy.md` for resolving the "Invalid Origin" error when logging in, including a `docker service update` command to set the correct `ALLOWED_ORIGINS`.
* Updated comments in `infra-templates/agents/agents.template.yaml` to provide guidance for running in privileged LXC containers.