### PR TITLE
feat(stacks): add Beszel env vars to homepage compose

### DIFF
--- a/stacks/homepage/docker-compose.yaml
+++ b/stacks/homepage/docker-compose.yaml
@@ -67,6 +67,11 @@ services:
             - HOMEPAGE_VAR_WG_EASY_URL=${HOMEPAGE_VAR_WG_EASY_URL}
             - HOMEPAGE_VAR_WG_EASY_PASSWORD=${HOMEPAGE_VAR_WG_EASY_PASSWORD}
             - HOMEPAGE_VAR_TDARR_URL=${HOMEPAGE_VAR_TDARR_URL}
+            - HOMEPAGE_VAR_BESZEL_URL=${HOMEPAGE_VAR_BESZEL_URL}
+            - HOMEPAGE_VAR_BESZEL_HOST_IP=${HOMEPAGE_VAR_BESZEL_HOST_IP}
+            - HOMEPAGE_VAR_BESZEL_USERNAME=${HOMEPAGE_VAR_BESZEL_USERNAME}
+            - HOMEPAGE_VAR_BESZEL_PASSWORD=${HOMEPAGE_VAR_BESZEL_PASSWORD}
+
         volumes:
             - /root/docker/homepage-stack/homepage/config:/app/config
             - /root/docker/homepage-stack/homepage/images:/app/public/images


### PR DESCRIPTION
Introduce environment variables for Beszel integration in the homepage docker-compose file. This enables configuration for URL, host IP, username, and password.

- HOMEPAGE_VAR_BESZEL_URL
- HOMEPAGE_VAR_BESZEL_HOST_IP
- HOMEPAGE_VAR_BESZEL_USERNAME
- HOMEPAGE_VAR_BESZEL_PASSWORD