### PR TITLE
refactor(infra-templates): rework beszel-agent config

### DIFF
--- a/infra-templates/agents/agents.template.yaml
+++ b/infra-templates/agents/agents.template.yaml
@@ -3,6 +3,22 @@
 #         - apparmor=unconfined
 
 services:
+    beszel-agent:
+        image: henrygd/beszel-agent:latest
+        container_name: beszel-agent
+        restart: unless-stopped
+        network_mode: host
+        volumes:
+            - /var/run/docker.sock:/var/run/docker.sock:ro
+            - ./beszel_agent_data:/var/lib/beszel-agent
+            # monitor other disks / partitions by mounting a folder in /extra-filesystems
+            # - /mnt/disk/.beszel:/extra-filesystems/sda1:ro
+        environment:
+            LISTEN: 45876
+            KEY: ${BESZEL_KEY}
+            TOKEN: ${BESZEL_TOKEN}
+            HUB_URL: http://<IP-OF-BESZEL-HUB-SERVER>:8090
+
     dockerproxy:
         image: ghcr.io/tecnativa/docker-socket-proxy:latest
         container_name: dockerproxy
@@ -16,21 +32,6 @@ services:
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock:ro
         restart: unless-stopped
-
-    beszel-agent:
-        image: henrygd/beszel-agent:latest
-        container_name: beszel-agent
-        restart: unless-stopped
-        network_mode: host
-        volumes:
-            - ./beszel-agent/beszel_agent_data:/var/lib/beszel-agent
-            - ./beszel-agent/beszel_socket:/beszel_socket
-            - /var/run/docker.sock:/var/run/docker.sock:ro
-        environment:
-            LISTEN: /beszel_socket/beszel.sock
-            HUB_URL: http://<IP-OF-BESZEL-HUB-SERVER>:8090
-            TOKEN: ${BESZEL_TOKEN}
-            KEY: ${BESZEL_KEY}
 
     portainer-agent:
         image: portainer/agent:latest


### PR DESCRIPTION
Switch agent to host network with TCP listener and simplified mounts for more reliable metrics collection and easier deployment.

- Replace socket-based setup with LISTEN port 45876
- Standardize data path and docker.sock mount