### PR TITLE
docs(readme-md): update stats and thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ This project is my **personal lab** and represents the real-world DevOps/SRE ski
 
 ## 📈 Stats at a Glance
 
-- **GitOps:** 11 stacks · 27 containers
-- **Portainer-managed fleet (all environments):** 29 stacks · 86 containers across 11 Docker environments
+- **GitOps:** 11 stacks · 28 containers
+- **Portainer-managed fleet (all environments):** 29 stacks · 95 containers across 11 Docker environments
 - **Resilience:** **RTO ≤ 3m** (Proxmox HA), **RPO ≈ 15m** (ZFS replication)
 - **Monitoring:** 64 checks in Uptime Kuma
 - **Availability snapshot:** Core infra **100%** · Exposed Services **99.79%** · Personal Websites **99.93%**
@@ -62,7 +62,7 @@ _Proxmox Dashboard:_
     - `dozzle-agent` - log aggregation
     - `docker-socket-proxy` - secure Docker API access
     - `watchtower` - scheduled image updates & Slack reporting
-    - Deployed on **11 Docker environments** → contributes to the **fleet total of 29 stacks / 86 containers**
+    - Deployed on **11 Docker environments** → contributes to the **fleet total of 29 stacks / 95 containers**
 
 - **CI/CD with Dokploy**
     - Webhook-triggered deployments for self-developed applications (Flask, Next.js, static sites, etc.), enabling seamless push-to-deploy workflows
@@ -87,7 +87,7 @@ The homelab uses a **multi-layer monitoring stack** to provide real-time insight
     - CPU >80% (10m)
     - Memory >80% (10m)
     - Disk >80% (10m)
-    - Temperature >80°C (10m)
+    - Temperature >85°C (10m)
 
 _Beszel Dashboard:_  
 ![Beszel Dashboard](assets/Beszel.jpeg)

--- a/proxmox-notes/vms/k8s-master-template.md
+++ b/proxmox-notes/vms/k8s-master-template.md
@@ -9,13 +9,13 @@ This guide walks through preparing a Proxmox VM for Kubernetes, setting up a sta
 ### Masters (3 nodes)
 
 - **CPU**: 2 vCPUs each
-- **RAM**: 4 GB each
+- **RAM**: 3 GB each
 - **Role**: Control-plane + etcd
 
 ### Workers (3 nodes)
 
 - **CPU**: 2 vCPUs each
-- **RAM**: 5 GB each
+- **RAM**: 4 GB each
 - **Role**: Application workloads (pods/services)
 
 ---


### PR DESCRIPTION
Refreshed container counts, Portainer totals, and monitoring temperature threshold in README. Adjusted k8s VM memory allocation in Proxmox notes for more efficient resource use.

- GitOps containers: 28
- Portainer containers: 95
- Temp threshold: 85°C
- Masters: 3 GB RAM, Workers: 4 GB RAM