### PR TITLE
feat(kubernetes): Grafana on Postgres; ingress

### DIFF
--- a/kubernetes/argocd/argocd-ingress.yaml
+++ b/kubernetes/argocd/argocd-ingress.yaml
@@ -4,9 +4,9 @@ metadata:
     name: argocd
     namespace: argocd
     annotations:
-        nginx.ingress.kubernetes.io/backend-protocol: "HTTPS" # ingress → service over HTTPS
-        nginx.ingress.kubernetes.io/ssl-redirect: "false" # NPM terminates TLS; keep HTTP between NPM and ingress
-        nginx.ingress.kubernetes.io/proxy-real-ip-cidr: "10.0.10.0/24" # optional: tighten from 0.0.0.0/0
+        nginx.ingress.kubernetes.io/backend-protocol: "HTTPS" # ingress -> service over HTTPS (avoids 80->443 redirects)
+        nginx.ingress.kubernetes.io/ssl-redirect: "false" # TLS terminates at NPM
+        nginx.ingress.kubernetes.io/proxy-real-ip-cidr: "10.0.10.0/24" # adjust to your LAN
 spec:
     ingressClassName: nginx
     rules:

--- a/kubernetes/monitoring/grafana-db-secret.yaml
+++ b/kubernetes/monitoring/grafana-db-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: grafana-db
+    namespace: monitoring
+type: Opaque
+stringData:
+    GF_DATABASE_PASSWORD: ChangeMe1234

--- a/kubernetes/monitoring/postgres-auth-secret.yaml
+++ b/kubernetes/monitoring/postgres-auth-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: postgres-auth
+    namespace: monitoring
+type: Opaque
+stringData:
+    POSTGRES_DB: grafana
+    POSTGRES_USER: grafana
+    POSTGRES_PASSWORD: ChangeMe1234

--- a/kubernetes/monitoring/postgres.yaml
+++ b/kubernetes/monitoring/postgres.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: postgres
+    namespace: monitoring
+spec:
+    clusterIP: None
+    ports:
+        - name: pg
+          port: 5432
+          targetPort: 5432
+    selector:
+        app: postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+    name: postgres
+    namespace: monitoring
+spec:
+    serviceName: postgres
+    replicas: 1
+    selector:
+        matchLabels:
+            app: postgres
+    template:
+        metadata:
+            labels:
+                app: postgres
+        spec:
+            terminationGracePeriodSeconds: 60
+            securityContext:
+                fsGroup: 999
+                fsGroupChangePolicy: "OnRootMismatch"
+            initContainers:
+                - name: init-perms
+                  image: busybox:1.36
+                  command:
+                      - sh
+                      - -lc
+                      - >
+                          mkdir -p /vol/pgdata &&
+                          chown -R 999:999 /vol/pgdata
+                  volumeMounts:
+                      - name: data
+                        mountPath: /vol
+            containers:
+                - name: postgres
+                  image: postgres:16
+                  securityContext:
+                      runAsUser: 999
+                      runAsGroup: 999
+                  ports:
+                      - name: pg
+                        containerPort: 5432
+                  envFrom:
+                      - secretRef:
+                            name: postgres-auth
+                  env:
+                      - name: PGDATA
+                        value: /var/lib/postgresql/data
+                  volumeMounts:
+                      - name: data
+                        mountPath: /var/lib/postgresql/data
+                        subPath: pgdata
+                  readinessProbe:
+                      exec:
+                          command: ["sh", "-lc", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+                      initialDelaySeconds: 10
+                      periodSeconds: 5
+                  livenessProbe:
+                      exec:
+                          command: ["sh", "-lc", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+                      initialDelaySeconds: 20
+                      periodSeconds: 10
+                  resources:
+                      requests:
+                          cpu: "100m"
+                          memory: "256Mi"
+    volumeClaimTemplates:
+        - metadata:
+              name: data
+          spec:
+              accessModes: ["ReadWriteOnce"]
+              storageClassName: longhorn
+              resources:
+                  requests:
+                      storage: 5Gi

--- a/kubernetes/monitoring/values.yaml
+++ b/kubernetes/monitoring/values.yaml
@@ -1,16 +1,27 @@
 grafana:
+    env:
+        GF_SERVER_ROOT_URL: http://grafana.homelab.local/
     persistence:
-        enabled: true
-        storageClassName: longhorn
-        size: 5Gi
+        enabled: false
+    grafana.ini:
+        session:
+            provider: database
+        database:
+            type: postgres
+            host: postgres.monitoring.svc.cluster.local:5432
+            name: grafana
+            user: grafana
+            ssl_mode: disable
+    envFromSecret: grafana-db
     ingress:
         enabled: true
         ingressClassName: nginx
         hosts: ["grafana.homelab.local"]
         path: /
+
 prometheus:
     prometheusSpec:
-        retention: 15d
+        retention: 7d
         storageSpec:
             volumeClaimTemplate:
                 spec:
@@ -23,6 +34,7 @@ prometheus:
         ingressClassName: nginx
         hosts: ["prometheus.homelab.local"]
         paths: ["/"]
+
 alertmanager:
     alertmanagerSpec:
         storage:


### PR DESCRIPTION
Move Grafana off SQLite to PostgreSQL and expose components via the existing ingress-nginx (fronted by NPM). Persist Prometheus and Alertmanager on Longhorn and trim retention to 7d to balance space and history. Refresh docs with end-to-end steps and NPM TLS flow.

- Add postgres StatefulSet + headless Service and auth secrets
- Configure Grafana DB via grafana.ini + envFromSecret
- Update kube-prometheus-stack values (PVCs, ingress, retention)
- Tweak Argo CD ingress annotations; expand README guidance

---

**Copilot Summary:**

This pull request refactors and enhances the Kubernetes monitoring and ingress setup, with a focus on improved persistence, security, and documentation. The most important changes are the migration of Grafana persistence from SQLite to PostgreSQL, the addition of detailed setup steps for TLS certificates and Nginx Proxy Manager, and the streamlining of the monitoring stack deployment and verification process.

**Monitoring stack improvements:**

* Migrated Grafana persistence from SQLite to PostgreSQL, including new secrets (`grafana-db`, `postgres-auth`) and a dedicated `postgres` StatefulSet on Longhorn for resilient storage. [[1]](diffhunk://#diff-b7adae6c719f08b5bf8d1b925b9cd2ca02d415c5d4beb44109a9cb10eebc1878R1-R8) [[2]](diffhunk://#diff-f138a7badada4ddb094b523468294f3ef07f72b34dd78cf7346845ae2eef163cR1-R10) [[3]](diffhunk://#diff-495d12e7f8c16283b72f62e1215fd5843f3646560e44cb04cb8ec4d13231216aR1-R88) [[4]](diffhunk://#diff-7d46015b7c4741945ad305813d47552954f6689f73c8c0a5eb917a1be11f78eaR2-R24)
* Updated Helm values for `kube-prometheus-stack` to configure Grafana to use PostgreSQL, set up Longhorn PVCs for Prometheus and Alertmanager, and tuned retention settings for Prometheus. [[1]](diffhunk://#diff-7d46015b7c4741945ad305813d47552954f6689f73c8c0a5eb917a1be11f78eaR2-R24) [[2]](diffhunk://#diff-7d46015b7c4741945ad305813d47552954f6689f73c8c0a5eb917a1be11f78eaR37)

**Ingress and TLS setup:**

* Added step-by-step instructions for generating a LAN-only wildcard certificate with `mkcert` and uploading it to Nginx Proxy Manager (NPM), improving local HTTPS security for all services. [[1]](diffhunk://#diff-169984e48e81136cbd5a36e19519626f498b9a40f8e8238347e6a924a424db17R7-R17) [[2]](diffhunk://#diff-169984e48e81136cbd5a36e19519626f498b9a40f8e8238347e6a924a424db17L993-R1120)
* Clarified and streamlined ingress configuration for Argo CD and monitoring services, with updated annotations and explicit separation of TLS termination at NPM. [[1]](diffhunk://#diff-17a1e0585cd6da159f368ff9800ca45e82bbb1ce0c6bd659294ca9e10ec6e53fL7-R9) [[2]](diffhunk://#diff-169984e48e81136cbd5a36e19519626f498b9a40f8e8238347e6a924a424db17L993-R1120) [[3]](diffhunk://#diff-169984e48e81136cbd5a36e19519626f498b9a40f8e8238347e6a924a424db17L1023-R1190)

**Documentation enhancements:**

* Reorganized and clarified the monitoring setup section in `kubernetes/README.md`, including prerequisites, deployment steps, verification, and cleanup instructions for legacy PVCs. [[1]](diffhunk://#diff-169984e48e81136cbd5a36e19519626f498b9a40f8e8238347e6a924a424db17L714-R900) [[2]](diffhunk://#diff-169984e48e81136cbd5a36e19519626f498b9a40f8e8238347e6a924a424db17L785-L878)
* Improved quick links and outcome summary for easier navigation and understanding of the cluster’s HA, storage, and observability setup. [[1]](diffhunk://#diff-169984e48e81136cbd5a36e19519626f498b9a40f8e8238347e6a924a424db17R7-R17) [[2]](diffhunk://#diff-169984e48e81136cbd5a36e19519626f498b9a40f8e8238347e6a924a424db17L1023-R1190)

**Other improvements:**

* Updated instructions for configuring NPM Proxy Hosts, including certificate selection and recommended options for security and compatibility.
* Enhanced verification and troubleshooting steps for monitoring and GitOps components, ensuring a smoother deployment experience. [[1]](diffhunk://#diff-169984e48e81136cbd5a36e19519626f498b9a40f8e8238347e6a924a424db17L785-L878) [[2]](diffhunk://#diff-169984e48e81136cbd5a36e19519626f498b9a40f8e8238347e6a924a424db17L993-R1120)

These changes provide a more robust, secure, and maintainable monitoring and ingress setup for the Kubernetes cluster.