### PR TITLE
fix(stacks): point Vaultwarden href to new var

### DIFF
--- a/stacks/homepage/config/services.yaml
+++ b/stacks/homepage/config/services.yaml
@@ -327,7 +327,7 @@
 - Utilities:
       - Vaultwarden:
             icon: bitwarden
-            href: "{{HOMEPAGE_VAR_VAULTWARDEN_NAS_REMOTE_URL}}"
+            href: "{{HOMEPAGE_VAR_VAULTWARDEN_REMOTE_URL}}"
             description: Self-hosted Bitwarden alternative
             server: ct-security
             container: vaultwarden


### PR DESCRIPTION
Replace HOMEPAGE_VAR_VAULTWARDEN_NAS_REMOTE_URL with HOMEPAGE_VAR_VAULTWARDEN_REMOTE_URL to align with the env var rename and avoid a broken link in the homepage config.