### PR TITLE
docs(proxmox-notes): clarify dokploy ingress setup

### DIFF
--- a/proxmox-notes/lxc/ct-dokploy.md
+++ b/proxmox-notes/lxc/ct-dokploy.md
@@ -18,13 +18,19 @@ This guide explains how to deploy applications using **Dokploy**, route traffic 
 ### Step 1: Expose App Port in Dokploy
 
 1. Navigate to your project in Dokploy.
-2. Go to **Advanced > Ports**
+2. Go to **Advanced > Ports**.
 3. Click **"Add Port"**:
     - **Published Port**: A unique external port (e.g., `10001`)
+    - **Published Port Mode**: Leave as **Ingress** (default and recommended)
     - **Target Port**: The internal app port (usually `3000` for Node/Next.js, depends on the app type)
     - **Protocol**: TCP
 
 4. Click **Create**, then **Redeploy** the app.
+
+⚡️ **Why Ingress?**  
+Ingress ensures containers are properly updated during redeployments and enables Swarm’s built-in load balancing if you add more nodes in the future.
+
+---
 
 ### Step 2: Assign Domain in Dokploy
 
@@ -32,10 +38,12 @@ This guide explains how to deploy applications using **Dokploy**, route traffic 
 2. Click **"Add Domain"**:
     - **Host**: e.g., `yourapp.example.com`
     - **Path**: `/`
-    - **Container Port**: `3000` (again, usually `3000` for Node/Next.js, depends on the app type)
-    - **HTTPS**: Enable, Certificate Provider=none (handled by NPM)
+    - **Container Port**: `3000` (usually `3000` for Node/Next.js, adjust if needed)
+    - **HTTPS**: Enable, Certificate Provider = **none** (since NPM handles SSL)
 
 3. Click **Create**.
+
+---
 
 ### Step 3: Configure Nginx Proxy Manager
 
@@ -43,8 +51,8 @@ This guide explains how to deploy applications using **Dokploy**, route traffic 
 2. Click **"Add Proxy Host"** (or edit an existing one):
     - **Domain Names**: `yourapp.example.com`
     - **Scheme**: `http`
-    - **Forward Hostname/IP**: `10.0.10.110`
-    - **Forward Port**: `10001`
+    - **Forward Hostname/IP**: `10.0.10.110` (the Dokploy/Swarm node’s IP)
+    - **Forward Port**: The **Published Port** you configured (e.g., `10001`)
     - Enable **Block Common Exploits** and **Websockets Support**
 
 3. Go to the **SSL** tab:
@@ -53,16 +61,19 @@ This guide explains how to deploy applications using **Dokploy**, route traffic 
     - Accept Terms and click **Save**
 
 4. Go to the **Advanced** tab:
-    - Fill in the following:
+    - Add the following:
 
     ```bash
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
     ```
 
-### Step 5: Test
+---
 
-Visit your app at `https://yourapp.example.com`. You should see the deployed app over HTTPS.
+### Step 4: Test
+
+Visit your app at `https://yourapp.example.com`.  
+You should see the deployed app over HTTPS with your wildcard SSL cert.
 
 ---
 
@@ -70,24 +81,25 @@ Visit your app at `https://yourapp.example.com`. You should see the deployed app
 
 Repeat the steps above using a new:
 
-- Published Port (e.g., `10002`, `10003`, ...)
+- Published Port (e.g., `10002`, `10003`, …)
 - Subdomain (e.g., `project2.example.com`, etc.)
 
-Only port `443` is needed open on your router for **all** apps.
+Only port **443** needs to be open on your router for **all apps**.
 
 ---
 
 ## Notes
 
-- SSL is terminated at Nginx Proxy Manager
-- Dokploy should not provision its own SSL certs (use NPM instead)
-- Wildcard domain DNS (`*.example.com`) must point to your server's WAN IP via Cloudflare
+- SSL is terminated at **Nginx Proxy Manager**.
+- Dokploy should **not** provision its own SSL certs when using this setup.
+- Wildcard domain DNS (`*.example.com`) must point to your server’s WAN IP via Cloudflare.
+- Ingress mode ensures smooth rolling updates and will give you load balancing automatically if you scale to multiple nodes later.
 
 ---
 
 ## "Invalid Origin" Error When Logging In Fix
 
-Run the following command to fix it:
+If you see “Invalid Origin” errors logging into Dokploy itself, run:
 
 ```bash
 docker service update \
@@ -96,4 +108,4 @@ docker service update \
   dokploy
 ```
 
-> Only use https://dokploy.example.com if you actually have it exposed to the internet via something like Nginx Proxy Manager.
+> Replace `https://dokploy.example.com` if you have Dokploy exposed to the internet via Nginx Proxy Manager.


### PR DESCRIPTION
Improve ct-dokploy notes with Ingress mode guidance, clearer Nginx Proxy Manager steps, and better SSL/domain instructions.

- Explain why Ingress is recommended (updates + load balancing)
- Standardize step numbering and formatting
- Refine SSL and DNS notes for Cloudflare/NPM users