### PR TITLE
fix(stacks): add PUID/PGID envs to media services

### DIFF
--- a/stacks/media-vpn/docker-compose.yaml
+++ b/stacks/media-vpn/docker-compose.yaml
@@ -48,6 +48,8 @@ services:
         container_name: qbittorrent
         environment:
             - TZ=America/New_York
+            - PUID=0
+            - PGID=0
             - WEBUI_PORT=9865
             - TORRENTING_PORT=${FIREWALL_VPN_INPUT_PORTS} # AirVPN Forwarded Port
         network_mode: service:gluetun

--- a/stacks/media/docker-compose.yaml
+++ b/stacks/media/docker-compose.yaml
@@ -5,6 +5,8 @@ services:
         network_mode: host
         environment:
             - TZ=America/New_York
+            - PUID=0
+            - PGID=0
         volumes:
             - /root/docker/media-stack/prowlarr/config:/config
         restart: unless-stopped
@@ -15,6 +17,8 @@ services:
         network_mode: host
         environment:
             - TZ=America/New_York
+            - PUID=0
+            - PGID=0
         volumes:
             - /root/docker/media-stack/radarr/config:/config
             - /mnt/nas-media/Movies:/movies
@@ -27,6 +31,8 @@ services:
         network_mode: host
         environment:
             - TZ=America/New_York
+            - PUID=0
+            - PGID=0
         volumes:
             - /root/docker/media-stack/sonarr/config:/config
             - /mnt/nas-media/TV Shows:/tv
@@ -44,6 +50,8 @@ services:
         environment:
             - TZ=America/New_York
             - VERSION=docker
+            - PUID=0
+            - PGID=0
             # - PLEX_CLAIM=your_claim_token
         volumes:
             - /root/docker/media-stack/plex:/config
@@ -58,6 +66,8 @@ services:
         network_mode: host
         environment:
             - TZ=America/New_York
+            - PUID=0
+            - PGID=0
         volumes:
             - /root/docker/media-stack/overseerr/config:/app/config
         restart: unless-stopped
@@ -68,6 +78,8 @@ services:
         network_mode: host
         environment:
             - TZ=America/New_York
+            - PUID=0
+            - PGID=0
             # Uncomment and adjust if needed
             # - BASE_PATH=/maintainerr         # serve from subdirectory
             # - UI_HOSTNAME=::                 # listen on IPv6 (default 0.0.0.0)
@@ -85,6 +97,8 @@ services:
             - /dev/dri:/dev/dri
         environment:
             - TZ=America/New_York
+            - PUID=0
+            - PGID=0
             - UMASK_SET=002
             - serverIP=0.0.0.0
             - serverPort=8266
@@ -109,6 +123,8 @@ services:
         container_name: recyclarr
         environment:
             - TZ=America/New_York
+            - PUID=0
+            - PGID=0
         volumes:
             - /root/docker/media-stack/recyclarr/config:/config
         restart: unless-stopped
@@ -120,6 +136,8 @@ services:
             - "${PORT:-8191}:8191"
         environment:
             - TZ=America/New_York
+            - PUID=0
+            - PGID=0
             - LOG_LEVEL=${LOG_LEVEL:-info}
             - LOG_HTML=${LOG_HTML:-false}
             - CAPTCHA_SOLVER=${CAPTCHA_SOLVER:-none}
@@ -133,6 +151,8 @@ services:
             - 8083:8081
         environment:
             - TZ=America/New_York
+            - PUID=0
+            - PGID=0
             - DELETE_FILE_ON_TRASHCAN=true
         volumes:
             - /mnt/nas-media/YouTube:/downloads


### PR DESCRIPTION
Added `PUID=0` and `PGID=0` to all linuxserver-based containers in media and media-vpn stacks. This aligns ownership with unprivileged CT setup and ensures proper file permissions on NFS shares.

- Updated prowlarr, radarr, sonarr, plex, overseerr, maintainerr, tdarr, recyclarr, flaresolverr, metube
- Updated qbittorrent in media-vpn

---

**Copilot Summary:**

This pull request updates the Docker Compose configurations for several media stack services to explicitly set user and group IDs for container processes. By adding the `PUID=0` and `PGID=0` environment variables, all containers will run as the root user and group, which can help avoid permission issues when accessing host-mounted volumes, but also has security implications. The changes are applied consistently across both the `media` and `media-vpn` stacks.

**Environment variable additions for user/group configuration:**

* Added `PUID=0` and `PGID=0` to the environment section of all major media services in `stacks/media/docker-compose.yaml`, including `prowlarr`, `radarr`, `sonarr`, `plex`, `overseerr`, `maintainerr`, `jellyfin`, `recyclarr`, `flare-solverr`, and `yt-dlp`. [[1]](diffhunk://#diff-1561d07a130763782b038100c924cd6ab5a68bb0e9ccc669f8e2b713569634b3R8-R9) [[2]](diffhunk://#diff-1561d07a130763782b038100c924cd6ab5a68bb0e9ccc669f8e2b713569634b3R20-R21) [[3]](diffhunk://#diff-1561d07a130763782b038100c924cd6ab5a68bb0e9ccc669f8e2b713569634b3R34-R35) [[4]](diffhunk://#diff-1561d07a130763782b038100c924cd6ab5a68bb0e9ccc669f8e2b713569634b3R53-R54) [[5]](diffhunk://#diff-1561d07a130763782b038100c924cd6ab5a68bb0e9ccc669f8e2b713569634b3R69-R70) [[6]](diffhunk://#diff-1561d07a130763782b038100c924cd6ab5a68bb0e9ccc669f8e2b713569634b3R81-R82) [[7]](diffhunk://#diff-1561d07a130763782b038100c924cd6ab5a68bb0e9ccc669f8e2b713569634b3R100-R101) [[8]](diffhunk://#diff-1561d07a130763782b038100c924cd6ab5a68bb0e9ccc669f8e2b713569634b3R126-R127) [[9]](diffhunk://#diff-1561d07a130763782b038100c924cd6ab5a68bb0e9ccc669f8e2b713569634b3R139-R140) [[10]](diffhunk://#diff-1561d07a130763782b038100c924cd6ab5a68bb0e9ccc669f8e2b713569634b3R154-R155)
* Added `PUID=0` and `PGID=0` to the `qbittorrent` service in `stacks/media-vpn/docker-compose.yaml`.