### PR TITLE
fix(kubernetes): adjust prometheus retention settings

### DIFF
--- a/kubernetes/monitoring/values.yaml
+++ b/kubernetes/monitoring/values.yaml
@@ -21,7 +21,9 @@ grafana:
 
 prometheus:
     prometheusSpec:
-        retention: 7d
+        retention: 1d
+        retentionSize: 4.5GB
+        walCompression: true
         storageSpec:
             volumeClaimTemplate:
                 spec:


### PR DESCRIPTION
Reduce Prometheus retention to 1d and enforce 4.5GB size cap with WAL compression enabled to prevent PVC from filling up.

- Prevents "no space left on device" crashloops
- Keeps storage usage aligned with 5Gi PVC limit

---

**Copilot Summary:**

This pull request makes adjustments to the Prometheus configuration in the `kubernetes/monitoring/values.yaml` file to optimize storage usage and performance.

Prometheus retention and storage optimizations:

* Reduced the Prometheus data retention period from 7 days to 1 day to minimize disk usage.
* Set a retention size limit of 4.5GB to further control storage consumption.
* Enabled WAL (Write-Ahead Log) compression to improve storage efficiency.