### PR TITLE
feat(stacks): add profilarr service to media stack

### DIFF
--- a/stacks/media/docker-compose.yaml
+++ b/stacks/media/docker-compose.yaml
@@ -129,6 +129,19 @@ services:
             - /root/docker/media-stack/recyclarr/config:/config
         restart: unless-stopped
 
+    profilarr:
+        image: santiagosayshey/profilarr:latest
+        container_name: profilarr
+        ports:
+            - "6868:6868"
+        volumes:
+            - /root/docker/media-stack/profilarr/config:/config
+        environment:
+            - TZ=America/New_York
+            - PUID=0
+            - PGID=0
+        restart: unless-stopped
+
     flaresolverr:
         image: 21hsmw/flaresolverr:nodriver
         container_name: flaresolverr


### PR DESCRIPTION
Introduce profilarr container to docker-compose for media stack. Enables new functionality on port 6868 with persistent config and basic environment setup.

- Adds image santiagosayshey/profilarr:latest
- Maps config volume and exposes port 6868