### PR TITLE
fix(stacks): add serverURL env and correct cron syntax

### DIFF
--- a/stacks/media/docker-compose.yaml
+++ b/stacks/media/docker-compose.yaml
@@ -103,6 +103,7 @@ services:
             - serverIP=0.0.0.0
             - serverPort=8266
             - webUIPort=8265
+            - serverURL=${TDARR_SERVER_URL}
             - internalNode=true
             - inContainer=true
             - ffmpegVersion=7
@@ -111,7 +112,7 @@ services:
             - apiKey=${TDARR_NODE_KEY} # Generated from Tools -> API Keys after creating a user and signing in
             - openBrowser=false
             - maxLogSizeMB=10
-            - cronPluginUpdate="0 0 * * *" # Daily at midnight
+            - cronPluginUpdate=0 0 * * * # Daily at midnight
         volumes:
             - /root/docker/media-stack/tdarr/server:/app/server
             - /root/docker/media-stack/tdarr/configs:/app/configs

--- a/stacks/media/stack.env.example
+++ b/stacks/media/stack.env.example
@@ -1,1 +1,2 @@
 TDARR_NODE_KEY=KeyGenedFromTools>API-Keys-in-tdarr
+TDARR_SERVER_URL=http://<YOUR-TDARR-IP>:8266


### PR DESCRIPTION
Introduce TDARR_SERVER_URL to ensure nodes connect to a resolvable address instead of 0.0.0.0. Also fix cron syntax by removing extra quotes for plugin updates.

- Updated docker-compose with serverURL variable
- Extended stack.env.example with TDARR_SERVER_URL

---

**Copilot Summary:**

This pull request updates the configuration for the Tdarr service in the media stack to improve environment variable usage and fix a syntax issue. The main changes involve adding a new environment variable for the server URL and correcting the cron syntax for plugin updates.

**Environment variable improvements:**

* Added a new `TDARR_SERVER_URL` environment variable to `stack.env.example` for specifying the Tdarr server URL.
* Updated the Tdarr service configuration in `docker-compose.yaml` to use the new `TDARR_SERVER_URL` environment variable for the `serverURL` parameter.

**Configuration fixes:**

* Fixed the syntax for the `cronPluginUpdate` environment variable in the Tdarr service configuration by removing unnecessary quotes.