### PR TITLE
fix(stacks): run maintainerr as root

### DIFF
--- a/stacks/media/docker-compose.yaml
+++ b/stacks/media/docker-compose.yaml
@@ -76,6 +76,7 @@ services:
         image: ghcr.io/jorenn92/maintainerr:latest
         container_name: maintainerr
         network_mode: host
+        user: "0:0"
         environment:
             - TZ=America/New_York
             - PUID=0


### PR DESCRIPTION
Set `user: "0:0"` in docker-compose to ensure the container can write to the bind-mounted data directory in an unprivileged LXC environment. This resolves the crash-restart loop.

- Remove reliance on unsupported PUID/PGID env vars
- Ensure compatibility with root-owned host paths