### PR TITLE
feat(stacks): add cleanuparr and huntarr services

### DIFF
--- a/stacks/media/docker-compose.yaml
+++ b/stacks/media/docker-compose.yaml
@@ -39,6 +39,19 @@ services:
             - /mnt/nas-media/Downloads:/downloads
         restart: unless-stopped
 
+    profilarr:
+        image: santiagosayshey/profilarr:latest
+        container_name: profilarr
+        ports:
+            - "6868:6868"
+        volumes:
+            - /root/docker/media-stack/profilarr/config:/config
+        environment:
+            - TZ=America/New_York
+            - PUID=0
+            - PGID=0
+        restart: unless-stopped
+
     plex:
         image: ghcr.io/linuxserver/plex:latest
         container_name: plex
@@ -122,28 +135,36 @@ services:
             - /mnt/tdarr-cache:/temp
         restart: unless-stopped
 
-    # recyclarr: # Replaced by Profilarr
-    #     image: ghcr.io/recyclarr/recyclarr:latest
-    #     container_name: recyclarr
-    #     environment:
-    #         - TZ=America/New_York
-    #         - PUID=0
-    #         - PGID=0
-    #     volumes:
-    #         - /root/docker/media-stack/recyclarr/config:/config
-    #     restart: unless-stopped
-
-    profilarr:
-        image: santiagosayshey/profilarr:latest
-        container_name: profilarr
-        ports:
-            - "6868:6868"
+    cleanuparr:
+        image: ghcr.io/cleanuparr/cleanuparr:latest
+        container_name: cleanuparr
+        network_mode: host
         volumes:
-            - /root/docker/media-stack/profilarr/config:/config
+            - /root/docker/media-stack/cleanuparr/config:/config
         environment:
             - TZ=America/New_York
             - PUID=0
             - PGID=0
+            - UMASK=022
+            - PORT=11011
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:11011/health"]
+            interval: 30s
+            timeout: 10s
+            start_period: 30s
+            retries: 3
+        restart: unless-stopped
+
+    huntarr:
+        image: ghcr.io/plexguide/huntarr:latest
+        container_name: huntarr
+        network_mode: host
+        environment:
+            - TZ=America/New_York
+            - PUID=0
+            - PGID=0
+        volumes:
+            - /root/docker/media-stack/huntarr/config:/config
         restart: unless-stopped
 
     flaresolverr:
@@ -174,3 +195,14 @@ services:
         volumes:
             - /mnt/nas-media/YouTube:/downloads
         restart: unless-stopped
+
+    # recyclarr: # Replaced by Profilarr
+    #     image: ghcr.io/recyclarr/recyclarr:latest
+    #     container_name: recyclarr
+    #     environment:
+    #         - TZ=America/New_York
+    #         - PUID=0
+    #         - PGID=0
+    #     volumes:
+    #         - /root/docker/media-stack/recyclarr/config:/config
+    #     restart: unless-stopped


### PR DESCRIPTION
Introduce Cleanuparr and Huntarr containers to the media stack. These tools automate cleanup of failed/malicious downloads and proactively hunt for missing or upgraded media.

- Added cleanuparr with healthcheck and host networking
- Added huntarr with host networking and config volume
- Moved recyclarr block to end as commented reference

---

**Copilot Summary:**

This pull request updates the `docker-compose.yaml` configuration for the media stack by introducing new services and reorganizing or commenting out existing ones. The main focus is on adding support for new media management tools and clarifying the replacement of `recyclarr` with `profilarr`.

New and updated services:

* Added new services:
  - Added the `profilarr` service, including its image, ports, volumes, and environment variables.
  - Added the `cleanuparr` service, with its image, configuration, healthcheck, environment variables, and host networking.
  - Added the `huntarr` service, specifying its image, configuration, and environment variables.

Service deprecation and clarification:

* Updated comments and placement for `recyclarr`:
  - Moved and clarified comments indicating that `recyclarr` is replaced by `profilarr`, and commented out the old `recyclarr` service definition. [[1]](diffhunk://#diff-1561d07a130763782b038100c924cd6ab5a68bb0e9ccc669f8e2b713569634b3L125-R167) [[2]](diffhunk://#diff-1561d07a130763782b038100c924cd6ab5a68bb0e9ccc669f8e2b713569634b3R198-R208)

Configuration improvements:

* Added healthcheck to `cleanuparr` to monitor service health via HTTP endpoint.