### PR TITLE
feat(stacks): add sabnzbd service to media stack

### DIFF
--- a/stacks/media/docker-compose.yaml
+++ b/stacks/media/docker-compose.yaml
@@ -39,6 +39,20 @@ services:
             - /mnt/nas-media/Downloads:/downloads
         restart: unless-stopped
 
+    sabnzbd:
+        image: lscr.io/linuxserver/sabnzbd:latest
+        container_name: sabnzbd
+        ports:
+            - "8080:8080"
+        environment:
+            - PUID=0
+            - PGID=0
+            - TZ=America/New_York
+        volumes:
+            - /root/docker/media-stack/sabnzbd/config:/config
+            - /mnt/nas-media/Downloads:/downloads
+        restart: unless-stopped
+
     profilarr:
         image: santiagosayshey/profilarr:latest
         container_name: profilarr


### PR DESCRIPTION
Introduce sabnzbd container in docker-compose for the media stack to support Usenet downloads and automation.

---

**Copilot Summary:**

This pull request adds a new service to the `media` Docker stack. Specifically, it introduces a configuration for running SABnzbd, a popular Usenet download client, alongside the existing services.

New service added:

* Added a `sabnzbd` service to `docker-compose.yaml` with configuration for image, container name, ports, environment variables, volumes, and restart policy.