### PR TITLE
feat(stacks): add tmpfs support for Plex transcodes

### DIFF
--- a/stacks/homepage/config/services.yaml
+++ b/stacks/homepage/config/services.yaml
@@ -299,7 +299,7 @@
 
 - Download Clients:
       - SABnzbd:
-            icon: SABnzbd
+            icon: sabnzbd
             href: "{{HOMEPAGE_VAR_SABNZBD_URL}}"
             description: Usenet newsreader
             server: ct-media

--- a/stacks/media/docker-compose.yaml
+++ b/stacks/media/docker-compose.yaml
@@ -80,10 +80,11 @@ services:
             - PUID=0
             - PGID=0
             # - PLEX_CLAIM=your_claim_token
+        tmpfs:
+            - /ram-transcode:size=6G
         volumes:
             - /root/docker/media-stack/plex:/config
             - /mnt/nas-media:/media
-            - /dev/shm/plex_transcode:/ram-transcode
             - /mnt/plex-nfs-transcode:/nfs-transcode
         restart: unless-stopped
 


### PR DESCRIPTION
Introduce RAM-backed tmpfs for Plex live transcodes and clarify NFS-backed storage for downloads. Also corrected SABnzbd icon name in homepage config.

- Add tmpfs mount in docker-compose for Plex
- Update documentation with clearer setup options
- Fix SABnzbd icon casing in services.yaml

---

**Copilot Summary:**

This pull request updates the Plex transcode directory configuration to clarify and improve the use of RAM-backed and NFS-backed directories for Plex transcoding. The documentation now provides clearer instructions for setting up these directories using Docker Compose, and the `docker-compose.yaml` file has been updated to match the recommended setup. Additionally, a minor icon naming fix was made in the homepage service configuration.

**Plex Transcode Directory Configuration Improvements:**

* Updated `proxmox-notes/lxc/ct-media-unprivileged.md` to clearly explain two options for creating a RAM-backed transcode directory, with a recommended Docker Compose `tmpfs` configuration for `/ram-transcode`. Also clarified steps for setting up the NFS-backed directory for downloads.
* Reorganized the documentation to specify where to set the transcode and download directories in the Plex Web UI, and clarified the purpose of each directory. [[1]](diffhunk://#diff-966dc7fa37bf40e59d21a2b9bf00a5ee3dc9daa7cba390f771da584fea1b252bL286-R319) [[2]](diffhunk://#diff-966dc7fa37bf40e59d21a2b9bf00a5ee3dc9daa7cba390f771da584fea1b252bR356-R367)

**Docker Compose Configuration Update:**

* Modified `stacks/media/docker-compose.yaml` to use the `tmpfs` option for mounting `/ram-transcode` as a 6GB RAM-backed directory, replacing the previous `/dev/shm/plex_transcode` mount.

**Homepage Service Configuration:**

* Fixed the icon name for SABnzbd in `stacks/homepage/config/services.yaml` to use the correct lowercase format.