### PR TITLE
feat(stacks): add media monitoring stack

### DIFF
--- a/stacks/media-monitoring-stack/docker-compose.yaml
+++ b/stacks/media-monitoring-stack/docker-compose.yaml
@@ -1,0 +1,107 @@
+services: # Monitoring and Observavility:
+    prometheus:
+        image: prom/prometheus:latest
+        container_name: prometheus
+        restart: unless-stopped
+        extra_hosts:
+            - "host.docker.internal:host-gateway"
+            # Allows access to host network from container
+        user: "0:0"
+        ports:
+            - 9090:9090/tcp
+        environment:
+            - TZ=America/New_York
+        volumes:
+            - /root/docker/media-monitoring-stack/prometheus/config/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+            - /root/docker/media-monitoring-stack/prometheus/config/rules:/etc/prometheus/rules:ro
+            - /root/docker/media-monitoring-stack/prometheus/data/:/prometheus
+        command:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+            - --storage.tsdb.retention.time=30d
+            - --web.enable-lifecycle
+            - --web.enable-admin-api
+
+    prometheus-plex-exporter:
+        container_name: prometheus-plex-exporter
+        image: ghcr.io/timothystewart6/prometheus-plex-exporter:latest
+        restart: unless-stopped
+        depends_on:
+            - plex
+        # ports:
+        # - 9000:9000/tcp
+        environment:
+            - TZ=America/New_York
+            - PLEX_SERVER=${PLEX_SERVER}
+            - PLEX_TOKEN=${PLEX_TOKEN}
+
+    node_exporter:
+        image: quay.io/prometheus/node-exporter:latest
+        container_name: node_exporter
+        restart: unless-stopped
+        network_mode: host
+        # ports:
+        #   - 9100:9100
+        command:
+            - "--path.rootfs=/host"
+            - "--path.procfs=/host/proc"
+            - "--path.sysfs=/host/sys"
+            - "--collector.cpu.info"
+        pid: host
+        environment:
+            - TZ=America/New_York
+        volumes:
+            - "/:/host:ro,rslave"
+
+    intel-gpu-exporter:
+        image: ghcr.io/clambin/intel-gpu-exporter:latest
+        container_name: intel-gpu-exporter
+        restart: unless-stopped
+        devices:
+            - /dev/dri:/dev/dri
+        privileged: true
+        pid: host
+        environment:
+            - TZ=America/New_York
+
+    smartctl-exporter:
+        image: quay.io/prometheuscommunity/smartctl-exporter:latest
+        container_name: smartctl-exporter
+        restart: unless-stopped
+        # privileged: true
+        user: root
+        environment:
+            - TZ=America/New_York
+
+    grafana:
+        image: grafana/grafana:latest
+        container_name: grafana
+        restart: unless-stopped
+        depends_on:
+            - prometheus
+        user: "0:0"
+        ports:
+            - 3000:3000/tcp
+        environment:
+            - TZ=America/New_York
+            - GF_SECURITY_ADMIN_USER=${GRAFANA_USER}
+            - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD}
+            - GF_SERVER_ROOT_URL=http://localhost:3000
+            - GF_USERS_ALLOW_SIGN_UP=false
+        volumes:
+            - /root/docker/media-monitoring-stack/grafana/data:/var/lib/grafana
+            - /root/docker/media-monitoring-stack/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
+            - /root/docker/media-monitoring-stack/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
+
+    cadvisor:
+        image: gcr.io/cadvisor/cadvisor:latest
+        container_name: cadvisor
+        restart: unless-stopped
+        environment:
+            - TZ=America/New_York
+        volumes:
+            - /:/rootfs:ro
+            - /var/run:/var/run:ro
+            - /sys:/sys:ro
+            - /var/lib/docker/:/var/lib/docker:ro
+            - /dev/disk/:/dev/disk:ro

--- a/stacks/media-monitoring-stack/stack.env.example
+++ b/stacks/media-monitoring-stack/stack.env.example
@@ -1,4 +1,4 @@
-TDARR_NODE_KEY=KeyGenedFromTools>API-Keys-in-tdarr
-TDARR_SERVER_URL=http://<YOUR-TDARR-IP>:8266
 PLEX_SERVER=https://<PLEX-HOST-IP>.bunchoflettersandnumbers.plex.direct:32400
 PLEX_TOKEN=X-Plex-Token
+GRAFANA_USER=user
+GRAFANA_PASSWORD=password

--- a/stacks/media/docker-compose.yaml
+++ b/stacks/media/docker-compose.yaml
@@ -67,7 +67,7 @@ services:
         restart: unless-stopped
 
     plex:
-        image: ghcr.io/linuxserver/plex:latest
+        image: lscr.io/linuxserver/plex:latest
         container_name: plex
         network_mode: host
         healthcheck:


### PR DESCRIPTION
Introduce `stacks/media-monitoring-stack` with Prometheus, Grafana, node_exporter, Intel GPU exporter, smartctl-exporter, cAdvisor, and Plex exporter for end-to-end observability.

- switch Plex image to lscr.io in media stack
- add stack.env.example for new stack

---

**Copilot Summary:**

This pull request introduces a comprehensive monitoring and observability stack for the media services, primarily through the addition of a new `docker-compose.yaml` file and supporting environment variables. It also updates the Plex image source and ensures all relevant environment variables are included for both monitoring and media stacks.

**Monitoring and Observability Stack:**

* Added a new `docker-compose.yaml` in `stacks/media-monitoring-stack` to deploy Prometheus, Grafana, node_exporter, smartctl-exporter, intel-gpu-exporter, cadvisor, and prometheus-plex-exporter services for system and Plex monitoring.
* Introduced a corresponding `stack.env.example` file with required environment variables for Plex and Grafana integration.

**Environment Variable Updates:**

* Added `PLEX_SERVER` and `PLEX_TOKEN` variables to the `stacks/media/stack.env.example` file to support monitoring integrations.

**Plex Image Source Update:**

* Updated the Plex Docker image source in `stacks/media/docker-compose.yaml` from `ghcr.io/linuxserver/plex` to `lscr.io/linuxserver/plex` for consistency with upstream changes.