### PR TITLE
chore(stacks): update prometheus config & gpu exporter

### DIFF
--- a/stacks/media-monitoring/docker-compose.yaml
+++ b/stacks/media-monitoring/docker-compose.yaml
@@ -14,6 +14,7 @@ services:
         volumes:
             - /root/docker/media-monitoring-stack/prometheus/config/prometheus.yml:/etc/prometheus/prometheus.yml:ro
             - /root/docker/media-monitoring-stack/prometheus/config/rules:/etc/prometheus/rules:ro
+            - /root/docker/media-monitoring-stack/prometheus/config/file_sd:/etc/prometheus/file_sd:ro
             - /root/docker/media-monitoring-stack/prometheus/data/:/prometheus
         command:
             - --config.file=/etc/prometheus/prometheus.yml
@@ -50,17 +51,6 @@ services:
             - TZ=America/New_York
         volumes:
             - "/:/host:ro,rslave"
-
-    intel-gpu-exporter:
-        image: ghcr.io/clambin/intel-gpu-exporter:latest
-        container_name: intel-gpu-exporter
-        restart: unless-stopped
-        devices:
-            - /dev/dri:/dev/dri
-        privileged: true
-        pid: host
-        environment:
-            - TZ=America/New_York
 
     smartctl-exporter:
         image: quay.io/prometheuscommunity/smartctl-exporter:latest
@@ -103,3 +93,15 @@ services:
             - /sys:/sys:ro
             - /var/lib/docker/:/var/lib/docker:ro
             - /dev/disk/:/dev/disk:ro
+
+    # On PVE nodes, run  the following service to expose the metrics:
+    # intel-gpu-exporter:
+    #     image: ghcr.io/onedr0p/intel-gpu-exporter:rolling
+    #     container_name: intel-gpu-exporter
+    #     restart: unless-stopped
+    #     privileged: true
+    #     pid: host
+    #     ports:
+    #         - 8082:8080
+    #     volumes:
+    #         - /dev/dri/:/dev/dri/


### PR DESCRIPTION
Added file_sd volume to Prometheus service and removed deprecated intel-gpu-exporter container. Documented updated intel-gpu-exporter usage for PVE nodes in comments.

- Improve Prometheus service discovery flexibility
- Clarify GPU exporter setup for specific environments

---

**Copilot Summary:**

This pull request makes updates to the `docker-compose.yaml` configuration for the media monitoring stack. The main changes involve improving Prometheus configuration flexibility and updating how the Intel GPU exporter service is handled. Notably, a new volume is added for Prometheus, and the Intel GPU exporter is removed from the default stack and replaced with commented instructions for manual deployment on specific nodes.

Prometheus configuration improvements:
* Added a new volume mount for Prometheus to include the `file_sd` directory, allowing dynamic service discovery configuration via files.

Intel GPU exporter changes:
* Removed the `intel-gpu-exporter` service from the default `docker-compose.yaml` stack, cleaning up unused or node-specific services.
* Added commented instructions at the end of the file to guide users on how to manually run the `intel-gpu-exporter` service on Proxmox VE (PVE) nodes, including updated image reference and port mapping.