### PR TITLE
fix(openwebui): avoid dev port conflict by mapping 3010->8080

### DIFF
--- a/stacks/openwebui/docker-compose.yaml
+++ b/stacks/openwebui/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
             WEB_LOADER_CONCURRENT_REQUESTS: 10
             SEARXNG_QUERY_URL: "http://searxng:8080/search?q=<query>"
         ports:
-            - "3000:8080"
+            - "3010:8080"
         volumes:
             - ${HOME}/docker-compose/openwebui/openwebui-data:/app/backend/data
 


### PR DESCRIPTION
## Context
OpenWebUI was mapped to host port 3000, which often conflicts with local dev servers (e.g., Next.js).

## Changes
- Update stacks/openwebui/docker-compose.yaml to map 3010:8080

## Testing
- Compose up should expose OpenWebUI at http://localhost:3010

## Risk/Rollback
- Low. If needed, revert mapping to 3000:8080.
