### PR TITLE
feat(media): add houndarr service for automated arr searches

### DIFF
--- a/stacks/media/docker-compose.yaml
+++ b/stacks/media/docker-compose.yaml
@@ -224,3 +224,16 @@ services:
             - /mnt/nas-media/Audiobooks:/audiobooks
             - /mnt/nas-media/Downloads:/downloads
         restart: unless-stopped
+
+    houndarr:
+        image: ghcr.io/av1155/houndarr:latest
+        container_name: houndarr
+        ports:
+            - "8877:8877"
+        environment:
+            - TZ=America/New_York
+            - PUID=0
+            - PGID=0
+        volumes:
+            - /root/docker/media-stack/houndarr/data:/data
+        restart: unless-stopped


### PR DESCRIPTION
## Summary

- Adds **Houndarr** (`ghcr.io/av1155/houndarr:latest`) to the media stack
- Runs on port `8877`, with persistent data at `/root/docker/media-stack/houndarr/data`
- Provides polite, rate-limited automatic searching for missing/cutoff-unmet media in Sonarr and Radarr — preventing indexer API overload from bulk searches

## Service Config

| Field | Value |
|---|---|
| Image | `ghcr.io/av1155/houndarr:latest` |
| Port | `8877:8877` |
| Data volume | `/root/docker/media-stack/houndarr/data:/data` |
| Restart policy | `unless-stopped` |
| TZ / PUID / PGID | `America/New_York` / `0` / `0` |