### PR TITLE
fix(media-vpn): disable watchtower updates for gluetun

### DIFF
--- a/stacks/media-vpn/docker-compose.yaml
+++ b/stacks/media-vpn/docker-compose.yaml
@@ -30,8 +30,8 @@ services:
             - "8191:8191" # Byparr
             - "9696:9696" # Prowlarr Web UI
         network_mode: bridge
-        # labels:
-        # - com.centurylinklabs.watchtower.enable=false
+        labels:
+            - com.centurylinklabs.watchtower.enable=false
         security_opt:
             - no-new-privileges:true
         volumes:


### PR DESCRIPTION
## Summary
- restore the watchtower disable label on the gluetun service
- prevent automatic updates for gluetun again

## Why
Gluetun is a bad candidate for unattended updates in this stack because image changes can disrupt VPN connectivity and break downstream services unexpectedly.