### PR TITLE
fix(ci): free runner disk and tidy Actions caches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -467,6 +467,23 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
 
+            - name: Free runner disk space
+              run: |
+                  set -euo pipefail
+                  echo "::group::Disk usage before cleanup"
+                  df -h /
+                  echo "::endgroup::"
+                  sudo rm -rf \
+                    /usr/share/dotnet \
+                    /usr/local/lib/android \
+                    /opt/ghc \
+                    /opt/hostedtoolcache/CodeQL \
+                    /usr/local/share/boost \
+                    /usr/local/share/powershell || true
+                  echo "::group::Disk usage after cleanup"
+                  df -h /
+                  echo "::endgroup::"
+
             - name: Login to Docker Hub
               if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
               uses: docker/login-action@v3
@@ -600,6 +617,8 @@ jobs:
                       --no-progress \
                       --db-repository "${TRIVY_DB_REPOSITORY}" \
                       "$img" 2>&1 | tee -a trivy.log || failed=1
+
+                    docker rmi "$img" >/dev/null 2>&1 || true
                     echo "::endgroup::"
                   done < images.txt
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -638,8 +638,8 @@ jobs:
                   path: ~/.cache/trivy
                   key: trivy-db-${{ runner.os }}-W${{ env.CACHE_EPOCH }}-v1
 
-            # --- Keep only the latest 4 weekly caches per OS ---
-            - name: Prune old Trivy caches (keep last 4)
+            # --- Keep only the latest N caches per prefix ---
+            - name: Prune old Actions caches
               if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
               env:
                   GH_TOKEN: ${{ github.token }}
@@ -664,27 +664,28 @@ jobs:
                   gh extension install actions/gh-actions-cache || true
 
                   REPO="${GITHUB_REPOSITORY}"
-                  PREFIX="trivy-db-${RUNNER_OS}-"
 
-                  # List cache keys, filter by prefix, sort descending (newest first)
-                  keys=$(gh actions-cache list -R "$REPO" \
-                    | awk '{print $1}' \
-                    | grep -E "^${PREFIX}" \
-                    | sort -r || true)
+                  prune_prefix() {
+                    local prefix="$1" keep="$2"
+                    local keys to_delete
+                    keys=$(gh actions-cache list -R "$REPO" \
+                      | awk '{print $1}' \
+                      | grep -E "^${prefix}" \
+                      | sort -r || true)
+                    to_delete=$(printf "%s\n" "$keys" | awk 'NF' | tail -n +"$((keep+1))" || true)
+                    if [[ -n "${to_delete}" ]]; then
+                      echo "Pruning old caches for '${prefix}' (keeping newest ${keep}):"
+                      printf "%s\n" "${to_delete}" | while read -r k; do
+                        echo " - $k"
+                        gh actions-cache delete "$k" -R "$REPO" --confirm || true
+                      done
+                    else
+                      echo "No old caches to prune for '${prefix}' (have ≤ ${keep})."
+                    fi
+                  }
 
-                  keep=4
-                  # Delete all but the newest $keep
-                  to_delete=$(printf "%s\n" "$keys" | awk 'NF' | tail -n +"$((keep+1))" || true)
-
-                  if [[ -n "${to_delete}" ]]; then
-                    echo "Pruning old Trivy caches:"
-                    printf "%s\n" "${to_delete}" | while read -r k; do
-                      echo " - $k"
-                      gh actions-cache delete "$k" -R "$REPO" --confirm || true
-                    done
-                  else
-                    echo "No old Trivy caches to prune (have ≤ ${keep})."
-                  fi
+                  prune_prefix "trivy-db-${RUNNER_OS}-" 4
+                  prune_prefix "broken-stacks-" 1
 
             - name: Summary
               if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -666,11 +666,11 @@ jobs:
                   REPO="${GITHUB_REPOSITORY}"
                   PREFIX="trivy-db-${RUNNER_OS}-"
 
-                  # List cache keys, filter by prefix, sort ascending (oldest first)
+                  # List cache keys, filter by prefix, sort descending (newest first)
                   keys=$(gh actions-cache list -R "$REPO" \
                     | awk '{print $1}' \
                     | grep -E "^${PREFIX}" \
-                    | sort || true)
+                    | sort -r || true)
 
                   keep=4
                   # Delete all but the newest $keep


### PR DESCRIPTION
## Summary

- Run [25063807853](https://github.com/av1155/homelab/actions/runs/25063807853) failed at the prune step in `Security — Container Images` with `No space left on device`. The Trivy scan itself succeeded but pulled and unpacked every image across all stacks, exhausting the runner before the prune step ran.
- Free ~30 GB up front by removing unused dotnet, Android, GHC, CodeQL, Boost, and PowerShell caches, then `docker rmi` each image after its scan so layers do not accumulate through the loop.
- Latent bug in the existing prune: it sorted ascending and then used `tail -n +$((keep+1))`, which would have deleted the newest caches once the active count exceeded the threshold. Fixed by sorting descending. Hidden so far because the active count stayed at 2.
- Extend the prune step to also keep `broken-stacks-` caches tidy. They are 211 bytes each so this is hygiene, not quota: GitHub auto-evicts after 7 days, but the workflow now actively keeps the newest 1.

Total cache usage at the time of writing: ~1.89 GB / 10 GB.

## Test plan

- [ ] `actionlint` and `yamllint` pass on this branch (validated locally).
- [ ] PR run of `CI — Validate Stacks, Security & Lint` finishes green; `Security — Container Images` no longer hits `No space left on device`.
- [ ] Disk-cleanup step output shows usable space recovered (visible in the runner log groups).
- [ ] After merge, the next scheduled run prunes any extra `broken-stacks-` caches down to 1.