### PR TITLE
feat(media): migrate profilarr to v2

### DIFF
--- a/stacks/media/docker-compose.yaml
+++ b/stacks/media/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
         restart: unless-stopped
 
     profilarr:
-        image: santiagosayshey/profilarr:latest
+        image: ghcr.io/dictionarry-hub/profilarr:latest
         container_name: profilarr
         ports:
             - "6868:6868"


### PR DESCRIPTION
## What

Switch `profilarr` from the deprecated `santiagosayshey/profilarr` Docker Hub image to the maintained `ghcr.io/dictionarry-hub/profilarr` image (v2).

## Why

The project moved to the Dictionarry-Hub org and released v2. Per the [official release notes](https://github.com/Dictionarry-Hub/profilarr/releases/tag/v2.0.0) and [v2 devlog](https://v2.dictionarry.dev/devlogs/profilarr-v2), **v2 is not compatible with v1**: the database, customisation, and appdata formats changed, so there is no in-place migration.

## Compose change

Image line only. Port `6868`, the `/config` volume path, `PUID/PGID=0`, `TZ`, and `no-new-privileges` are unchanged. `ORIGIN` is not needed because profilarr is not fronted by the reverse-proxy stack (accessed directly on `:6868`).

## Host cutover (manual, on ct-media)

This is a fresh start, not a data migration:

1. `docker compose stop profilarr`
2. `mv config config.v1-backup && mkdir config` (keeps v1 appdata for rollback)
3. `docker compose pull profilarr && docker compose up -d profilarr`
4. Complete in-app onboarding at `http://<host>:6868` (login, link database, connect Radarr/Sonarr, configure sync)
5. Once confirmed working, `rm -rf config.v1-backup`

**Rollback:** revert the image line, then `rm -rf config && mv config.v1-backup config`, redeploy.