### PR TITLE
fix(media): plex healthcheck uses curl; move prowlarr off the VPN

### DIFF
--- a/stacks/media-vpn/docker-compose.yaml
+++ b/stacks/media-vpn/docker-compose.yaml
@@ -28,7 +28,6 @@ services:
             - "${FIREWALL_VPN_INPUT_PORTS}:${FIREWALL_VPN_INPUT_PORTS}" # AirVPN TCP
             - "${FIREWALL_VPN_INPUT_PORTS}:${FIREWALL_VPN_INPUT_PORTS}/udp" # AirVPN UDP
             - "8191:8191" # Byparr
-            - "9696:9696" # Prowlarr Web UI
         network_mode: bridge
         labels:
             - com.centurylinklabs.watchtower.enable=false
@@ -67,21 +66,6 @@ services:
             timeout: 10s
             retries: 3
             start_period: 20s
-
-    prowlarr:
-        image: ghcr.io/linuxserver/prowlarr:latest
-        container_name: prowlarr
-        network_mode: service:gluetun
-        environment:
-            - TZ=America/New_York
-            - PUID=0
-            - PGID=0
-        volumes:
-            - /root/docker/media-vpn-stack/prowlarr/config:/config
-        depends_on:
-            gluetun:
-                condition: service_healthy
-        restart: unless-stopped
 
     byparr:
         image: ghcr.io/thephaseless/byparr:latest

--- a/stacks/media/docker-compose.yaml
+++ b/stacks/media/docker-compose.yaml
@@ -1,4 +1,16 @@
 services:
+    prowlarr:
+        image: ghcr.io/linuxserver/prowlarr:latest
+        container_name: prowlarr
+        network_mode: host
+        environment:
+            - TZ=America/New_York
+            - PUID=0
+            - PGID=0
+        volumes:
+            - /root/docker/media-stack/prowlarr/config:/config
+        restart: unless-stopped
+
     radarr:
         image: ghcr.io/linuxserver/radarr:latest
         container_name: radarr
@@ -61,7 +73,11 @@ services:
         container_name: plex
         network_mode: host
         healthcheck:
-            test: wget --no-verbose --tries=1 --spider http://localhost:32400/web || exit 1
+            test: curl -fsS --connect-timeout 5 --max-time 10 http://127.0.0.1:32400/identity || exit 1
+            start_period: 60s
+            interval: 30s
+            timeout: 15s
+            retries: 5
         devices:
             - /dev/dri:/dev/dri
         environment:


### PR DESCRIPTION
## Summary

Two media-stack maintenance changes, shipped together.

### 1. Plex healthcheck: wget -> curl (fixes `unhealthy`)

The `lscr.io/linuxserver/plex` image is Ubuntu-based, ships **curl** (not `wget`), and defines **no `HEALTHCHECK`** of its own. The compose healthcheck called `wget`, so it failed with `wget: not found` (exit 127) and Docker flagged the container **unhealthy** even though Plex was running fine. A watchtower image update recreated the container, which re-ran the always-failing check and surfaced the state in Portainer.

Verified on the running container:

- `command -v wget` -> not found
- `command -v curl` -> `/usr/bin/curl`
- `curl .../identity` -> **HTTP 200**; `curl .../web` -> **302** (redirect)

New check:

```
curl -fsS --connect-timeout 5 --max-time 10 http://127.0.0.1:32400/identity || exit 1
```

- `/identity` returns 200 with no token and no redirect (so `--fail` works without `-L`).
- `127.0.0.1` avoids the `localhost` -> `::1` resolution gotcha.
- Docker `timeout` (15s) > curl `--max-time` (10s) so curl's error surfaces instead of a SIGKILL.
- `start_period: 60s` gives slow Plex starts a grace window (there was none).

### 2. Prowlarr: back to the media stack (revert #98 / #99)

Remove the `prowlarr` service and gluetun's `9696` port from `media-vpn`, and restore `prowlarr` to the `media` stack with `network_mode: host` and the `/root/docker/media-stack/prowlarr/config` volume — as it was before it was routed through the VPN. Indexer traffic no longer exits via the VPN (intended).

## Deploy / test plan

- Portainer GitOps redeploys both stacks on merge to `main`.
- Prowlarr's config was already moved on the host to the media-stack path.
- Post-deploy expectations: Plex flips to `healthy`; Prowlarr reachable at `host:9696` with indexers intact; gluetun no longer publishes `9696`.
